### PR TITLE
creating fonts.dir to avoid xset error #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Please submit a pull request if there are any bdf/pcf fonts that you want added.
 git clone https://github.com/Tecate/bitmap-fonts.git
 cd bitmap-fonts
 sudo cp -avr bitmap/ /usr/share/fonts
+cd /usr/share/fonts/bitmap/
+sudo mkfontdir
+sudo mkfontscale
 xset fp+ /usr/share/fonts/bitmap
 fc-cache -fv
 ```


### PR DESCRIPTION
while installing most of people may live problems with xset because fonts.dir is not created by default. Putting this to avoid problems and faster installations.